### PR TITLE
feat(digitalocean): added support for`vpc_uuid` instead of `private_networking`

### DIFF
--- a/digitalocean/single_server/deployment.tf
+++ b/digitalocean/single_server/deployment.tf
@@ -16,4 +16,5 @@ module "kasm" {
   admin_password              = "changeme"
   allow_ssh_cidrs             = ["0.0.0.0/0"]
   ssh_key_fingerprints        = []
+  vpc_uuid                    = ""
 }

--- a/digitalocean/single_server/module/server.tf
+++ b/digitalocean/single_server/module/server.tf
@@ -13,6 +13,7 @@ resource "digitalocean_droplet" "kasm-server" {
   image              = "${var.digital_ocean_image}"
   region             = "${var.digital_ocean_region}"
   size               = "${var.digital_ocean_droplet_slug}"
+  vpc_uuid           = "${var.vpc_uuid}"
   private_networking = false
   backups            = false
   ipv6               = false

--- a/digitalocean/single_server/module/variables.tf
+++ b/digitalocean/single_server/module/variables.tf
@@ -43,3 +43,7 @@ variable swap_size {
   description = "The amount of swap (in MB) to configure inside the compute instances"
   default = 2048
 }
+
+variable vpc_uuid {
+  description = "The UUID of the VPC to deploy the kasm server into"
+}


### PR DESCRIPTION
When I first ran the terraform script(s) to deploy to a single DigitalOcean server, a message appeared stating that the `private_networking` property is deprecated in favor of `vpc_uuid`.

This pull request adds the `vpc_uuid` property as a variable that can be passed in via the `deployment.tf` file.

Please note this is my first contribution to the **kasmtech** organization, so I apologize in advance if I'm missing anything important or if there are some steps I should take before opening a PR like this.